### PR TITLE
Feature Add: Skip Regeneration as per #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Clone the repository and install dependencies:
 - `--detailed`: Include detailed analysis. Default: False.
 - `--html`: Generate HTML output. Default: False.
 - `--I`: Interactive mode. Default: False.
+- `--skip_regenration (bool)`: Skip regeneration of existing instruction.json might be generated in previous or parallel runs. Default: False.
 
 ## Questions for datasets
 

--- a/py2dataset.uml
+++ b/py2dataset.uml
@@ -14,6 +14,7 @@ def main():
     --single_process: Use a single process to process Python files. Defaults to False.
     --detailed: Include detailed analysis. Defaults to False.
     --html: Generate HTML output. Defaults to False.
+    --skip_regenration: Skip regeneration of existing instruction.json. Defaults to False
     --I: Interactive mode. Defaults to False.;
 
 :py2dataset.py:


### PR DESCRIPTION
As per suggested Idea discussion at https://github.com/jeffmeloy/py2dataset/discussions/13#discussion-5983357
Modified code to include the option to skip regeneration of instruct.json file for a traversed python file with a intent to save CPU/GPU time.